### PR TITLE
Use iterators for callback indexing instead of pointers

### DIFF
--- a/Documentation/Examples/Editor/scenario.cpp
+++ b/Documentation/Examples/Editor/scenario.cpp
@@ -47,212 +47,210 @@ shared_ptr<TimeConstraint> main_constraint;
 
 int main()
 {
-    /* 
+    /*
      Network setup
      */
-    
+
     // create a Local device "i-score"
     auto local_protocol = Local::create();
     auto local_device = Device::create(local_protocol, "i-score");
-    
+
     // add a /play address
     auto local_play_node = *(local_device->emplace(local_device->children().cend(), "play"));
     auto local_play_address = local_play_node->createAddress(Value::Type::BOOL);
-    
+
     // attach /play address to a callback
-    ValueCallback local_play_value_callback = local_play_callback;
-    local_play_address->addCallback(&local_play_value_callback);
-    
+    local_play_address->addCallback(local_play_callback);
+
     // add a /test address
     auto local_test_node = *(local_device->emplace(local_device->children().cend(), "test"));
     auto local_test_address = local_test_node->createAddress(Value::Type::TUPLE);
-    
+
     // attach /test address to their callback
-    ValueCallback local_test_value_callback = local_test_callback;
-    local_test_address->addCallback(&local_test_value_callback);
-    
+    local_test_address->addCallback(local_test_callback);
+
     // filter repetitions
     local_test_address->setRepetitionFilter(true);
-    
+
     /*
      Main Scenario setup
      */
-    
+
     // create the start and the end TimeNodes
     auto main_start_node = TimeNode::create();
     auto main_end_node = TimeNode::create();
-    
+
     // create TimeEvents inside TimeNodes and make them interactive to the /play address
     auto main_start_event = *(main_start_node->emplace(main_start_node->timeEvents().begin(), &event_callback));
     auto main_end_event = *(main_end_node->emplace(main_end_node->timeEvents().begin(), &event_callback));
 
     // create the main Scenario
     auto main_scenario = Scenario::create();
-    
+
     // create the main TimeConstraint
     TimeValue main_duration(5000.);
     main_constraint = TimeConstraint::create(main_constraint_callback, main_start_event, main_end_event, main_duration);
-    
+
     // add the scenario to the main TimeConstraint
     main_constraint->addTimeProcess(main_scenario);
 
-    /* 
+    /*
      Main Scenario edition : creation of a two TimeConstraints
      */
-    
+
     // get the start node of the main Scenario
     auto scenario_start_node = main_scenario->getStartNode();
-    
+
     // create a TimeNode
     auto first_end_node = TimeNode::create();
 
     // create a TimeEvent inside the scenario start node without Expression
     auto first_start_event = *(scenario_start_node->emplace(scenario_start_node->timeEvents().begin(), &event_callback));
-    
+
     // create a TimeEvent inside the end node without Expression
     auto first_end_event = *(first_end_node->emplace(first_end_node->timeEvents().begin(), &event_callback));
-    
+
     // create a TimeConstraint between the two TimeEvents
     TimeValue first_duration(1500.);
     auto first_constraint = TimeConstraint::create(first_constraint_callback, first_start_event, first_end_event, first_duration, first_duration, first_duration);
-    
+
     // add the first TimeConstraint to the main Scenario
     main_scenario->addTimeConstraint(first_constraint);
-    
+
     // create a TimeNode
     auto second_end_node = TimeNode::create();
-    
+
     // create a TimeEvent inside the end node without Expression
     auto second_end_event = *(second_end_node->emplace(second_end_node->timeEvents().begin(), &event_callback));
-    
+
     // create a TimeConstraint between the two TimeEvents
     TimeValue second_duration(2000.);
     auto second_constraint = TimeConstraint::create(second_constraint_callback, first_end_event, second_end_event, second_duration, second_duration, second_duration);
-    
+
     // add the second TimeConstraint to the main Scenario
     main_scenario->addTimeConstraint(second_constraint);
-    
+
     /*
      Main Scenario edition : make an event interactive
      */
-    
+
     // create an expression : /i-score/test >= {0.7, 0.7, 0.7}
     Destination local_test(local_test_node);
     Tuple threshold1 = {new Float(0.7), new Float(0.7), new Float(0.7)};
     auto next_expression1 = ExpressionAtom::create(&local_test,
                                                   ExpressionAtom::Operator::GREATER_THAN_OR_EQUAL,
                                                   &threshold1);
-    
+
     // set first end event expression to make it interactive
     first_end_event->setExpression(next_expression1);
-    
+
     /*
      Main Scenario edition : creation of two Automations
      */
-    
+
     // create a linear curve to drive all element of the Tuple value from 0. to 1.
     auto first_curve = Curve<float>::create();
     auto first_linearSegment = CurveSegmentLinear<float>::create(first_curve);
-    
+
     first_curve->setInitialValue(0.);
     first_curve->addPoint(1., 1., first_linearSegment);
-    
+
     // create a power curve to drive all element of the Tuple value from 0. to 2.
     auto second_curve = Curve<float>::create();
     auto second_powerSegment = CurveSegmentPower<float>::create(first_curve);
     second_powerSegment->setPower(0.5);
-    
+
     second_curve->setInitialValue(1.);
     second_curve->addPoint(1., 2., second_powerSegment);
-    
+
     // create a Tuple value of 3 Behavior values based on the same curve
     vector<const Value*> t_first_curves = {new Behavior(first_curve), new Behavior(first_curve), new Behavior(first_curve)};
     Tuple first_curves(t_first_curves);
-    
+
     // create a Tuple value of 3 Behavior values based on the same curve
     vector<const Value*> t_second_curves = {new Behavior(second_curve), new Behavior(second_curve), new Behavior(second_curve)};
     Tuple second_curves(t_second_curves);
-    
+
     // create a first Automation to drive /test address by the linear curve
     auto first_automation = Automation::create(local_test_address, &first_curves);
-    
+
     // create a second Automation to drive /test address by the power curve
     auto second_automation = Automation::create(local_test_address, &second_curves);
-    
+
     // add the first Automation to the first TimeConstraint
     first_constraint->addTimeProcess(first_automation);
-    
+
     // add the second Automation to the second TimeConstraint
     second_constraint->addTimeProcess(second_automation);
-    
+
     // add "/test 0. 0. 0." message to first Automation's start State
     Tuple zero = {new Float(0.), new Float(0.), new Float(0.)};
     auto first_start_message = Message::create(local_test_address, &zero);
     first_automation->getStartState()->stateElements().push_back(first_start_message);
-    
+
     // add "/test 1. 1. 1." message to first Automation's end State
     Tuple one = {new Float(1.), new Float(1.), new Float(1.)};
     auto first_end_message = Message::create(local_test_address, &one);
     first_automation->getEndState()->stateElements().push_back(first_end_message);
-    
+
     // add "/test 2. 2. 2." message to second Automation's end State
     Tuple two = {new Float(2.), new Float(2.), new Float(2.)};
     auto second_end_message = Message::create(local_test_address, &two);
     second_automation->getEndState()->stateElements().push_back(second_end_message);
-    
+
     /*
      Main Scenario operation : miscellaneous
      */
-    
+
     // display TimeNode's date
     cout << "first_start_node date = " << scenario_start_node->getDate() << endl;
     cout << "first_end_node date = " << first_end_node->getDate() << endl;
     cout << "second_end_node date = " << second_end_node->getDate() << endl;
-    
+
     // change main TimeConstraint speed, granularity and offset
     main_constraint->setSpeed(1.);
     main_constraint->setGranularity(50.);
-    
+
     // change first and second TimeConstraint speed and granularity
     first_constraint->setSpeed(1.);
     first_constraint->setGranularity(250.);
     second_constraint->setSpeed(1.);
     second_constraint->setGranularity(250.);
-    
+
     cout << "***** START *****" << endl;
-    
+
     // play the main TimeConstraint
     local_play_address->pushValue(&True);
-    
+
     // wait the main TimeConstraint end
     while (main_constraint->getRunning())
         ;
-    
+
     cout << "***** END *****" << endl;
-    
+
     // set minimal duration of the first constraint to 1000 ms
     first_constraint->setDurationMin(1000.);
-    
+
     // changing expression to : /i-score/test >= {0.5, 0.5, 0.5}
     Tuple threshold2 = {new Float(0.5), new Float(0.5), new Float(0.5)};
     auto next_expression2 = ExpressionAtom::create(&local_test,
                                                    ExpressionAtom::Operator::GREATER_THAN_OR_EQUAL,
                                                    &threshold2);
-    
+
     // set first end event expression to make it interactive
     first_end_event->setExpression(next_expression2);
-    
+
     cout << "***** START *****" << endl;
-    
+
     // play it again faster starting at 500 ms
     main_constraint->setSpeed(2.);
     main_constraint->setOffset(500.);
     local_play_address->pushValue(&True);
-    
+
     // wait the main TimeConstraint end
     while (main_constraint->getRunning())
         ;
-    
+
     cout << "***** END *****" << endl;
 }
 
@@ -271,11 +269,11 @@ void local_play_callback(const Value * v)
 void local_test_callback(const Value * v)
 {
     cout << "/i-score/test = ";
-    
+
     if (v->getType() == Value::Type::TUPLE)
     {
         Tuple * t = (Tuple*)v;
-        
+
         for (auto e : t->value)
         {
             if (e->getType() == Value::Type::FLOAT)
@@ -285,7 +283,7 @@ void local_test_callback(const Value * v)
             }
         }
     }
-    
+
     cout << endl;
 }
 
@@ -298,7 +296,7 @@ void main_constraint_callback(const TimeValue& position, const TimeValue& date, 
 void first_constraint_callback(const TimeValue& position, const TimeValue& date, shared_ptr<StateElement> element)
 {
     cout << "First Constraint : " << double(position) << ", " << double(date) << endl;
-    
+
     // don't launch element here as the element produced by the first TimeConstraint is handled by the main TimeConstraint
 }
 

--- a/Documentation/Examples/Editor/state.cpp
+++ b/Documentation/Examples/Editor/state.cpp
@@ -55,7 +55,7 @@ int main()
             for (const auto& parameter : module->children())
             {
                 string parameter_name = parameter->getName();
-                
+
                 if (parameter_name == "bitdepth")
                 {
                     cout << "/deg/bitdepth node found" << endl;
@@ -66,10 +66,9 @@ int main()
                     // change the value
                     Int i(10);
                     bitdepthAddress->pushValue(&i);
-                    
+
                     // attach to callback to display later value update
-                    ValueCallback callback = printValueCallback;
-                    bitdepthAddress->addCallback(&callback);
+                    bitdepthAddress->addCallback(printValueCallback);
                 }
                 else if (parameter_name == "samplerate_ratio")
                 {
@@ -81,15 +80,14 @@ int main()
                     // change the value
                     Float f(0.5);
                     samplerateAddress->pushValue(&f);
-                    
+
                     // attach to callback to display later value update
-                    ValueCallback callback = printValueCallback;
-                    samplerateAddress->addCallback(&callback);
+                    samplerateAddress->addCallback(printValueCallback);
                 }
             }
         }
     }
-    
+
     cout << "editing and launching state" << endl;
 
     // fill the state
@@ -98,18 +96,18 @@ int main()
 
     // trigger the message
     test->launch();
-    
+
     cout << "waiting for /deg/samplerate_ratio > 0.5" << endl;
-    
+
     // wait while samplerate_ratio > 0.5
     bool wait = true;
     while (wait)
     {
         this_thread::sleep_for( std::chrono::milliseconds(500));
-        
+
         Float* f = (Float*)samplerateAddress->getValue();
         wait = f->value > 0.5;
-        
+
         if (!wait)
              cout << "done !" << endl;
     }

--- a/Documentation/Examples/Network/Minuit_exploration.cpp
+++ b/Documentation/Examples/Network/Minuit_exploration.cpp
@@ -37,7 +37,7 @@ int main()
   {
     // explore the tree of B
     minuitDevice->updateNamespace();
-    
+
     // display tree in console
     explore(minuitDevice);
   }
@@ -48,18 +48,17 @@ void explore(const shared_ptr<Node> node)
     for (const auto& child : node->children())
     {
         cout << child->getName();
-        
+
         auto address = child->getAddress();
-        
+
         if (address)
         {
             // attach to callback to display value update
-            ValueCallback callback = printValueCallback;
-            address->addCallback(&callback);
-            
+            address->addCallback(printValueCallback);
+
             // update the value
             address->pullValue();
-            
+
             // display address info
             cout << " : ";
             switch (address->getValueType())
@@ -128,7 +127,7 @@ void explore(const shared_ptr<Node> node)
                 default:
                     break;
             }
-            
+
             cout << ", AccessMode(";
             switch (address->getAccessMode())
             {
@@ -150,7 +149,7 @@ void explore(const shared_ptr<Node> node)
                 default:
                     break;
             }
-            
+
             cout << "), BoundingMode(";
             switch (address->getBoundingMode())
             {
@@ -177,14 +176,14 @@ void explore(const shared_ptr<Node> node)
                 default:
                     break;
             }
-            
+
             cout << "), Domain(";
             printDomain(address->getDomain());
             cout << ")";
         }
-        
+
         cout << "\n";
-        
+
         explore(child);
     }
 }

--- a/Documentation/Examples/Network/Minuit_publication.cpp
+++ b/Documentation/Examples/Network/Minuit_publication.cpp
@@ -40,60 +40,59 @@ int main()
      /test/my_tuple
      */
 
-    ValueCallback callback = printValueCallback;
-    
+
     auto localTestNode = *(localDevice->emplace(localDevice->children().cend(), "test"));
-    
+
     auto localImpulseNode = *(localTestNode->emplace(localTestNode->children().cend(), "my_impulse"));
     auto localImpulseAddress = localImpulseNode->createAddress(Value::Type::IMPULSE);
-    localImpulseAddress->addCallback(&callback);
-    
+    localImpulseAddress->addCallback(printValueCallback);
+
     auto localBoolNode = *(localTestNode->emplace(localTestNode->children().cend(), "my_bool"));
     auto localBoolAddress = localBoolNode->createAddress(Value::Type::BOOL);
-    localBoolAddress->addCallback(&callback);
-    
+    localBoolAddress->addCallback(printValueCallback);
+
     auto localIntNode = *(localTestNode->emplace(localTestNode->children().cend(), "my_int"));
     auto localIntAddress = localIntNode->createAddress(Value::Type::INT);
-    localIntAddress->addCallback(&callback);
-    
+    localIntAddress->addCallback(printValueCallback);
+
     auto localFloatNode = *(localTestNode->emplace(localTestNode->children().cend(), "my_float"));
     auto localFloatAddress = localFloatNode->createAddress(Value::Type::FLOAT);
-    localFloatAddress->addCallback(&callback);
-    
+    localFloatAddress->addCallback(printValueCallback);
+
     auto localStringNode = *(localTestNode->emplace(localTestNode->children().cend(), "my_string"));
     auto localStringAddress = localStringNode->createAddress(Value::Type::STRING);
-    localStringAddress->addCallback(&callback);
-    
+    localStringAddress->addCallback(printValueCallback);
+
     auto localDestinationNode = *(localTestNode->emplace(localTestNode->children().cend(), "my_destination"));
     auto localDestinationAddress = localDestinationNode->createAddress(Value::Type::DESTINATION);
-    localDestinationAddress->addCallback(&callback);
-    
+    localDestinationAddress->addCallback(printValueCallback);
+
     auto localTupleNode = *(localTestNode->emplace(localTestNode->children().cend(), "my_tuple"));
     auto localTupleAddress = localTupleNode->createAddress(Value::Type::TUPLE);
-    localTupleAddress->addCallback(&callback);
-    
+    localTupleAddress->addCallback(printValueCallback);
+
     // update tree value
     Impulse n;
     localImpulseAddress->pushValue(&n);
-    
+
     Bool b(true);
     localBoolAddress->pushValue(&b);
-    
+
     Int i(5);
     localIntAddress->pushValue(&i);
-    
+
     Float f(0.5);
     localFloatAddress->pushValue(&f);
-    
+
     String s("hello world !");
     localStringAddress->pushValue(&s);
-    
+
     Destination d(localFloatNode);
     localDestinationAddress->pushValue(&d);
-    
+
     Tuple t = {new Float(0.1), new Float(0.2), new Float(0.3)};
     localTupleAddress->pushValue(&t);
-    
+
     // declare a distant program "A" as a Minuit device
     auto minuitProtocol = Minuit::create("127.0.0.1", 9999, 6666);
     auto minuitDevice = Device::create(minuitProtocol, "A");

--- a/Documentation/Examples/Network/OSC.cpp
+++ b/Documentation/Examples/Network/OSC.cpp
@@ -27,7 +27,7 @@ int main()
     // declare this program "P" as an OSC device
     auto oscProtocol = OSC::create("127.0.0.1", 9996, 9997);
     auto oscDevice = Device::create(oscProtocol, "P");
-    
+
     /* publish each feature of program "P" as address into a tree
      /test
      /test/my_bang
@@ -39,60 +39,58 @@ int main()
      /test/my_tuple
      */
 
-    ValueCallback callback = printValueCallback;
-    
     auto oscTestNode = *(oscDevice->emplace(oscDevice->children().cend(), "test"));
-    
+
     auto oscImpulseNode = *(oscTestNode->emplace(oscTestNode->children().cend(), "my_impulse"));
     auto oscImpulseAddress = oscImpulseNode->createAddress(Value::Type::IMPULSE);
-    oscImpulseAddress->addCallback(&callback);
-    
+    oscImpulseAddress->addCallback(printValueCallback);
+
     auto oscBoolNode = *(oscTestNode->emplace(oscTestNode->children().cend(), "my_bool"));
     auto oscBoolAddress = oscBoolNode->createAddress(Value::Type::BOOL);
-    oscBoolAddress->addCallback(&callback);
-    
+    oscBoolAddress->addCallback(printValueCallback);
+
     auto oscIntNode = *(oscTestNode->emplace(oscTestNode->children().cend(), "my_int"));
     auto oscIntAddress = oscIntNode->createAddress(Value::Type::INT);
-    oscIntAddress->addCallback(&callback);
-    
+    oscIntAddress->addCallback(printValueCallback);
+
     auto oscFloatNode = *(oscTestNode->emplace(oscTestNode->children().cend(), "my_float"));
     auto oscFloatAddress = oscFloatNode->createAddress(Value::Type::FLOAT);
-    oscFloatAddress->addCallback(&callback);
-    
+    oscFloatAddress->addCallback(printValueCallback);
+
     auto oscStringNode = *(oscTestNode->emplace(oscTestNode->children().cend(), "my_string"));
     auto oscStringAddress = oscStringNode->createAddress(Value::Type::STRING);
-    oscStringAddress->addCallback(&callback);
-    
+    oscStringAddress->addCallback(printValueCallback);
+
     auto oscDestinationNode = *(oscTestNode->emplace(oscTestNode->children().cend(), "my_destination"));
     auto oscDestinationAddress = oscDestinationNode->createAddress(Value::Type::DESTINATION);
-    oscDestinationAddress->addCallback(&callback);
-    
+    oscDestinationAddress->addCallback(printValueCallback);
+
     auto oscTupleNode = *(oscTestNode->emplace(oscTestNode->children().cend(), "my_tuple"));
     auto oscTupleAddress = oscTupleNode->createAddress(Value::Type::TUPLE);
-    oscTupleAddress->addCallback(&callback);
-    
+    oscTupleAddress->addCallback(printValueCallback);
+
     // update tree value
     Impulse n;
     oscImpulseAddress->setValue(&n);
-    
+
     Bool b(true);
     oscBoolAddress->setValue(&b);
-    
+
     Int i(5);
     oscIntAddress->setValue(&i);
-    
+
     Float f(0.5);
     oscFloatAddress->setValue(&f);
-    
+
     String s("hello world !");
     oscStringAddress->setValue(&s);
-    
+
     Destination d(oscFloatNode);
     oscDestinationAddress->setValue(&d);
-    
+
     Tuple t = {new Float(0.1), new Float(0.2), new Float(0.3)};
     oscTupleAddress->setValue(&t);
-    
+
     while (true)
         ;
 }

--- a/Headers/Editor/Clock.h
+++ b/Headers/Editor/Clock.h
@@ -28,16 +28,16 @@ class Clock
 {
 
 public:
-  
+
   /*! to get the clock execution back
    \param clock position
    \param clock date
    \param dropped ticks */
   using ExecutionCallback = std::function<void(const TimeValue&, const TimeValue&, unsigned char)>;
-  
+
 # pragma mark -
 # pragma mark Life cycle
-  
+
   /*! factory
    \param duration
    \param granularity
@@ -49,77 +49,77 @@ public:
                                        const TimeValue& = 1.,
                                        const TimeValue& = 0.,
                                        float = 1.);
-  
+
   /*! destructor */
   virtual ~Clock() = default;
 
 # pragma mark -
 # pragma mark Execution
-  
+
   /*! start the clock */
   virtual void start() = 0;
-  
+
   /*! halt the clock */
   virtual void stop() = 0;
-  
+
   /*! pause the clock progression */
   virtual void pause() = 0;
-  
+
   /*! resume the clock progression */
   virtual void resume() = 0;
-  
+
   /*! called every time a new step should be processed.
    \details can be use to force step processing in case of external drive but the callback will not be called
    \return bool true if the clock ticks */
   virtual bool tick() = 0;
-  
+
 # pragma mark -
 # pragma mark Accessors
-  
+
   /*! get the duration of the clock
    \return const #TimeValue duration */
   virtual const TimeValue & getDuration() const = 0;
-  
+
   /*! set the duration of the clock execution
    \param const #TimeValue duration
    \return #Clock the clock */
   virtual Clock & setDuration(const TimeValue&) = 0;
-  
+
   /*! get the granularity of the clock
    \return const #TimeValue granularity */
   virtual const TimeValue & getGranularity() const = 0;
-  
+
   /*! set the granularity of the clock execution
    \param const #TimeValue granularity
    \return #Clock the clock */
   virtual Clock & setGranularity(const TimeValue&) = 0;
-  
+
   /*! get the offset of the clock
    \return const #TimeValue offset */
   virtual const TimeValue & getOffset() const = 0;
-  
+
   /** set the offset of the clock
    \param const #TimeValue offset
    \return #Clock the clock */
   virtual Clock & setOffset(const TimeValue&) = 0;
-  
+
   /*! get the speed of the clock
    \return const #TimeValue speed */
   virtual float getSpeed() const = 0;
-  
+
   /** set the speed factor attribute
    \param float speed factor
    \return #Clock the clock */
   virtual Clock & setSpeed(float) = 0;
-  
+
   /*! get the running status of the clock
    \return bool true if is running */
   virtual bool getRunning() const = 0;
-  
+
   /*! get the position of the clock
    \return const #TimeValue position */
   virtual const TimeValue & getPosition() const = 0;
-  
+
   /*! get the date of the clock
    \return const #TimeValue date */
   virtual const TimeValue & getDate() const = 0;

--- a/Headers/Editor/Expression.h
+++ b/Headers/Editor/Expression.h
@@ -23,7 +23,7 @@
 
 namespace OSSIA
 {
-  
+
 /*! to get the result back
  \param the returned result */
 using ResultCallback = std::function<void(bool)>;
@@ -32,29 +32,29 @@ class Expression : public CallbackContainer<ResultCallback>
 {
 
 public:
-
+  using iterator = typename CallbackContainer<ResultCallback>::iterator;
 # pragma mark -
 # pragma mark Life cycle
-  
+
   /*! factory
    \param bool result to return
    \return std::shared_ptr<#Expression> */
   static std::shared_ptr<Expression> create(bool = false);
-  
+
   /*! destructor */
   virtual ~Expression() = default;
-  
+
 # pragma mark -
 # pragma mark Execution
-  
-  /*! evaluate the expression 
+
+  /*! evaluate the expression
    \return bool result of the evaluation */
   virtual bool evaluate() const = 0;
-  
+
 };
-  
+
 static std::shared_ptr<Expression> ExpressionFalse = Expression::create(false);
 static std::shared_ptr<Expression> ExpressionTrue = Expression::create(true);
-  
+
 }
 

--- a/Headers/Misc/CallbackContainer.h
+++ b/Headers/Misc/CallbackContainer.h
@@ -15,50 +15,56 @@
 
 #pragma once
 
-#include <vector>
+#include <list>
 
 namespace OSSIA
 {
-  
 template <typename T>
 class CallbackContainer
 {
-  
+
 public:
-  
+
 # pragma mark -
 # pragma mark Life cycle
-  
+
   /*! destructor */
   virtual ~CallbackContainer() = default;
-  
+
 # pragma mark -
 # pragma mark Callback
-  
+
   /*! to store a set of callback functions */
-  using CallbackVector = typename std::vector<T*>;
-  
+  using CallbackVector = typename std::list<T>;
+  using iterator = typename CallbackVector::const_iterator;
+
   /*! add a callback function
-   \param #T function pointer */
-  virtual void addCallback(T*) = 0;
-  
+   \param #T function object */
+  virtual iterator addCallback(T callback)
+  {
+    return m_callbacks.insert(callbacks().cend(), std::move(callback));
+  }
+
   /*! remove a result callback function
-   \param #T function pointer */
-  virtual void removeCallback(T*) = 0;
-  
+   \param #it Iterator to remove */
+   virtual void removeCallback(iterator it)
+   {
+     m_callbacks.erase(it);
+   }
+
   /*! get callback functions
    \return #CallbackList */
   CallbackVector& callbacks()
   { return m_callbacks; }
-  
+
   /*! get callback functions
    \return #CallbackList */
   const CallbackVector& callbacks() const
   { return m_callbacks; }
-  
+
 protected:
   CallbackVector m_callbacks;
-  
+
 };
-  
+
 }

--- a/Headers/Network/Address.h
+++ b/Headers/Network/Address.h
@@ -1,6 +1,6 @@
 /*!
  * \file Address.h
- * 
+ *
  * \defgroup Network
  *
  * \brief
@@ -31,15 +31,15 @@ class Node;
 /*! to get the value back
  \param the returned value */
 using ValueCallback = std::function<void(const Value *)>;
-  
+
 class Address : public CallbackContainer<ValueCallback>
 {
 
 public:
-
+  using iterator = typename CallbackContainer<ValueCallback>::iterator;
 # pragma mark -
 # pragma mark Enumerations
-  
+
   /*! operation allowed on address */
   enum class AccessMode
   {
@@ -47,7 +47,7 @@ public:
     SET,
     BI
   };
-  
+
   /*! address behaviors at crossing domain boundaries time */
   enum class BoundingMode
   {
@@ -59,22 +59,22 @@ public:
 
 # pragma mark -
 # pragma mark Life cycle
-  
+
   /*! destructor */
   virtual ~Address() = default;
-  
+
 # pragma mark -
 # pragma mark Network
-  
+
   /*! get the node where the address is
    \return std::shared_ptr<#Node> the node where the address is */
   virtual const std::shared_ptr<Node> getNode() const = 0;
-  
+
   /*! pull and return the address value from a device using its protocol
    \see Protocol::pullAddressValue method
    \return const #Value* the value */
   virtual const Value * pullValue() = 0;
-  
+
   /*! set then push the address value to a device using its protocol
    \see Protocol::pushAddressValue method
    \param const #Value* the value (push the current value if no argument)
@@ -83,18 +83,18 @@ public:
 
 # pragma mark -
 # pragma mark Accessors
-  
+
   /*! get the address value
    \details call pullValue if you need to sync the value with the device
    \return const #Value* the value */
   virtual const Value * getValue() const = 0;
-  
+
   /*! set the address value
    \note call pushValue if you need to sync the value with the device
-   \param const #Value* the value 
+   \param const #Value* the value
    \return #Address the address */
   virtual Address & setValue(const Value*) = 0;
-  
+
   /*! get the address type
    \return #Value::Type of the address */
   virtual Value::Type getValueType() const = 0;
@@ -102,36 +102,36 @@ public:
   /*! get the address access mode
    \return #AccessMode of the address */
   virtual AccessMode getAccessMode() const = 0;
-  
+
   /*! set the address access mode
-   \param #AccessMode of the address 
+   \param #AccessMode of the address
    \return #Address the address */
   virtual Address & setAccessMode(AccessMode) = 0;
-  
-  /*! get the address domain 
+
+  /*! get the address domain
    \return #Domain of the address */
   virtual const std::shared_ptr<Domain> & getDomain() const = 0;
-  
+
   /*! set the address domain
    \param #Domain of the address
    \return #Address the address */
   virtual Address & setDomain(std::shared_ptr<Domain>) = 0;
-  
+
   /*! get the address bounding mode
    \todo multiple ?
    \return #BoundingMode of the address */
   virtual BoundingMode getBoundingMode() const = 0;
-  
+
   /*! set the address bounding mode
    \todo multiple ?
    \param #BoundingMode of the address
    \return #Address the address */
   virtual Address & setBoundingMode(BoundingMode) = 0;
-  
+
   /*! get the address repetition filter status
    \return bool true is repetition filter is enabled */
   virtual bool getRepetitionFilter() const = 0;
-  
+
   /*! set the address repetition filter status
    \param bool true is to enable repetition filter
    \return #Address the address */

--- a/Implementations/Jamoma/Includes/Editor/JamomaTimeEvent.h
+++ b/Implementations/Jamoma/Includes/Editor/JamomaTimeEvent.h
@@ -28,75 +28,76 @@ using namespace std;
 
 class JamomaTimeEvent : public TimeEvent, public enable_shared_from_this<JamomaTimeEvent>
 {
-  
+
 private:
-  
+
 # pragma mark -
 # pragma mark Implementation specific
-  
+
   TimeEvent::ExecutionCallback  mCallback;
-  
+
   shared_ptr<TimeNode>          mTimeNode;
   shared_ptr<State>             mState;
   shared_ptr<Expression>        mExpression;
   Status                        mStatus;
-  
+
   bool                          mObserveExpression;
   ResultCallback                mResultCallback;
+  Expression::iterator          mResultCallbackIndex;
 
 public:
-  
+
 # pragma mark -
 # pragma mark Life cycle
-  
+
   JamomaTimeEvent(TimeEvent::ExecutionCallback,
                   shared_ptr<TimeNode> aTimeNode = nullptr,
                   shared_ptr<Expression> anExpression = nullptr);
-  
+
   ~JamomaTimeEvent();
 
 # pragma mark -
 # pragma mark Execution
-  
+
   void happen() override;
-  
+
   void dispose() override;
-  
+
 # pragma mark -
 # pragma mark Edition
-  
+
   void addState(const std::shared_ptr<State>) override;
-  
+
   void removeState(const std::shared_ptr<State>) override;
 
 # pragma mark -
 # pragma mark Accessors
-  
+
   const shared_ptr<TimeNode> & getTimeNode() const override;
-  
+
   const shared_ptr<State> & getState() const override;
-  
+
   const shared_ptr<Expression> & getExpression() const override;
-  
+
   TimeEvent & setExpression(const std::shared_ptr<Expression>) override;
-  
+
   Status getStatus() const override;
-  
+
 # pragma mark -
 # pragma mark Implementation specific
-  
-  /* edit status and call ExecutionCallback 
+
+  /* edit status and call ExecutionCallback
    \param #Status new status */
   void setStatus(Status);
-  
+
   /* check if NONE TimeEvent is ready to become PENDING */
   void process();
-  
+
   /* is the TimeEvent observing its Expression ? */
   bool isObservingExpression();
-  
+
 private:
-  
+
   void observeExpressionResult(bool);
   void resultCallback(bool result);
 };

--- a/Implementations/Jamoma/Includes/Network/JamomaAddress.h
+++ b/Implementations/Jamoma/Includes/Network/JamomaAddress.h
@@ -30,23 +30,23 @@ class JamomaAddress : public Address
 {
 
   friend JamomaProtocol;
-  
+
 private:
 
 # pragma mark -
 # pragma mark Implementation specific
-  
+
   weak_ptr<Node>      mNode;
-  
+
   mutable TTObject    mObject;
   mutable Value *     mValue{};
   Value::Type         mValueType;
   AccessMode          mAccessMode;
   BoundingMode        mBoundingMode;
   bool                mRepetitionFilter;
-  
+
   shared_ptr<Domain>  mDomain;
-  
+
   ValueCallback       mCallback;
 
 public:
@@ -55,18 +55,18 @@ public:
 # pragma mark Life cycle
 
   JamomaAddress(shared_ptr<Node> node, TTObject aData = TTObject());
-  
+
   ~JamomaAddress();
-  
+
 # pragma mark -
 # pragma mark Network
-  
+
   const shared_ptr<Node> getNode() const override;
-  
+
   const Value * pullValue() override;
-  
+
   Address & pushValue(const Value * = nullptr) override;
-  
+
 # pragma mark -
 # pragma mark Accessors
 
@@ -79,11 +79,11 @@ public:
   AccessMode getAccessMode() const override;
 
   Address & setAccessMode(AccessMode) override;
-  
+
   const shared_ptr<Domain> & getDomain() const override;
-  
+
   Address & setDomain(shared_ptr<Domain>) override;
-  
+
   BoundingMode getBoundingMode() const override;
 
   Address & setBoundingMode(BoundingMode) override;
@@ -91,13 +91,13 @@ public:
   bool getRepetitionFilter() const override;
 
   Address & setRepetitionFilter(bool) override;
- 
+
 # pragma mark -
 # pragma mark Callback Container
-  
-  void addCallback(ValueCallback*) override;
-  
-  void removeCallback(ValueCallback*) override;
+
+  Address::iterator addCallback(ValueCallback) override;
+
+  void removeCallback(Address::iterator) override;
 
 # pragma mark -
 # pragma mark Implementation specific
@@ -107,8 +107,8 @@ private:
   static TTErr TTValueCallback(const TTValue&, const TTValue&);
 
   Value * convertTTValueIntoValue(const TTValue&, Value::Type) const;
-  
+
   void convertValueIntoTTValue(const Value *, TTValue &) const;
-  
+
   string buildNodePath(shared_ptr<Node>) const;
 };

--- a/Implementations/Jamoma/Sources/Editor/Expression.cpp
+++ b/Implementations/Jamoma/Sources/Editor/Expression.cpp
@@ -6,41 +6,44 @@ using namespace std;
 
 class JamomaExpression : public Expression
 {
-  
+
 private:
-  
+
 # pragma mark -
 # pragma mark Implementation specific
-  
+
   bool m_result;
-  
+
 public:
-  
+
 # pragma mark -
 # pragma mark Life cycle
-  
+
   JamomaExpression(bool result) :
   m_result(result)
   {}
-  
+
   ~JamomaExpression()
   {}
 
 # pragma mark -
 # pragma mark Execution
-  
+
   bool evaluate() const override
   {
     return m_result;
   }
-  
+
 # pragma mark -
 # pragma mark Callback Container
-  
-  void addCallback(ResultCallback* callback) override
-  {}
-  
-  void removeCallback(ResultCallback* callback) override
+
+  //! \todo shouldn't they stay unimplemented ?
+  Expression::iterator addCallback(ResultCallback) override
+  {
+      return callbacks().end();
+  }
+
+  void removeCallback(Expression::iterator callback) override
   {}
 };
 

--- a/Implementations/Jamoma/Sources/Editor/ExpressionNot.cpp
+++ b/Implementations/Jamoma/Sources/Editor/ExpressionNot.cpp
@@ -13,8 +13,9 @@ private:
 # pragma mark Implementation specific
 
   shared_ptr<Expression>  mExpression;
-  
+
   ResultCallback          mResultCallback;
+  Expression::iterator    mResultCallbackIndex;
 
 public:
 
@@ -50,25 +51,27 @@ public:
 # pragma mark -
 # pragma mark Callback Container
 
-  void addCallback(ResultCallback* callback) override
+  Expression::iterator addCallback(ResultCallback callback) override
   {
-    callbacks().push_back(callback);
+    auto it = CallbackContainer::addCallback(std::move(callback));
 
     if (callbacks().size() == 1)
     {
       // start expression observation
-      mExpression->addCallback(&mResultCallback);
+      mResultCallbackIndex = mExpression->addCallback(mResultCallback);
     }
+
+    return it;
   }
 
-  void removeCallback(ResultCallback* callback) override
+  void removeCallback(Expression::iterator callback) override
   {
-    callbacks().erase(std::find(callbacks().begin(), callbacks().end(), callback));
+    CallbackContainer::removeCallback(callback);
 
     if (callbacks().size() == 0)
     {
       // stop expression observation
-      mExpression->removeCallback(&mResultCallback);
+      mExpression->removeCallback(mResultCallbackIndex);
     }
   }
 
@@ -79,16 +82,16 @@ public:
   {
     return mExpression;
   }
-  
+
 private:
-  
+
 # pragma mark -
 # pragma mark Implementation Specific
-  
+
   void resultCallback(bool result)
   {
     for (auto callback : callbacks())
-      (*callback)(!result);
+      callback(!result);
   }
 };
 

--- a/Implementations/Jamoma/Sources/Network/Address.cpp
+++ b/Implementations/Jamoma/Sources/Network/Address.cpp
@@ -15,15 +15,15 @@ mRepetitionFilter(false)
   if (mObject.valid())
   {
     TTSymbol objectName = mObject.name();
-    
+
     if (objectName == kTTSym_Mirror)
       objectName = TTMirrorPtr(mObject.instance())->getName();
-    
+
     if (objectName == "Data")
     {
       TTSymbol type;
       mObject.get("type", type);
-      
+
       if (type == kTTSym_none)
       {
         mValue = new Impulse();
@@ -59,20 +59,20 @@ mRepetitionFilter(false)
         mValue = new OSSIA::String();
         mValueType = Value::Type::STRING;
       }
-      
+
       TTSymbol service;
       mObject.get("service", service);
-      
+
       if (service == kTTSym_parameter)
         mAccessMode = AccessMode::BI;
       else if (service == kTTSym_message)
         mAccessMode = AccessMode::SET;
       else if (service == kTTSym_return)
         mAccessMode = AccessMode::GET;
-      
+
       TTValue range;
       mObject.get("rangeBounds", range);
-      
+
       if (type == kTTSym_none)
       {
         mDomain = Domain::create();
@@ -113,13 +113,13 @@ mRepetitionFilter(false)
         // we need to know the size of the array to setup the domain
         TTValue v;
         mObject.get("value", v);
-        
+
         vector<const Value*> tuple_min;
         vector<const Value*> tuple_max;
         for (unsigned long i = 0; i < v.size(); i++)
           tuple_min.push_back(new OSSIA::Float(range[0]));
         tuple_max.push_back(new OSSIA::Float(range[1]));
-        
+
         mDomain = Domain::create(new OSSIA::Tuple(tuple_min), new OSSIA::Tuple(tuple_max));
       }
       else if (type == kTTSym_string)
@@ -137,10 +137,10 @@ mRepetitionFilter(false)
       {
         mDomain = Domain::create();
       }
-      
+
       TTSymbol clipmode;
       mObject.get("rangeClipmode", clipmode);
-      
+
       if (clipmode == kTTSym_none)
         mBoundingMode = BoundingMode::FREE;
       else if (clipmode == kTTSym_low)
@@ -153,15 +153,15 @@ mRepetitionFilter(false)
         mBoundingMode = BoundingMode::WRAP;
       else if (clipmode == kTTSym_fold)
         mBoundingMode = BoundingMode::FOLD;
-      
+
       mObject.get("repetitionFilter", mRepetitionFilter);
-      
+
       // enable callback to be notified each time the value change
       TTObject    callback("callback");
       TTValue     args(TTPtr(this), mObject);
       callback.set("baton", args);
       callback.set("function", TTPtr(&JamomaAddress::TTValueCallback));
-      
+
       TTAttributePtr attribute;
       mObject.instance()->findAttribute("value", &attribute);
       attribute->registerObserverForNotifications(callback);
@@ -195,17 +195,17 @@ const Value * JamomaAddress::pullValue()
 {
   //! \todo move the code below into each protocol pullAddressValue method
   //! \todo use the device protocol to pull address value
-  
+
   TTValue v;
   if (!mObject.get("value", v))
   {
     // clear former value
     delete mValue;
-  
+
     // create new value
     mValue = convertTTValueIntoValue(v, mValueType);
   }
-  
+
   return mValue;
 }
 
@@ -213,10 +213,10 @@ Address & JamomaAddress::pushValue(const Value * value)
 {
   if (value != nullptr)
     setValue(value);
-  
+
   //! \todo move the code below into each protocol pushAddressValue method
   //! \todo use the device protocol to push address value
-  
+
   TTValue v;
   convertValueIntoTTValue(mValue, v);
 
@@ -224,7 +224,7 @@ Address & JamomaAddress::pushValue(const Value * value)
     mObject.send("Command", v);
   else
     mObject.set("value", v);
-  
+
   return *this;
 }
 
@@ -240,10 +240,10 @@ Address & JamomaAddress::setValue(const Value * value)
 {
   // clear former value
   delete mValue;
-  
+
   // copy the new value
   mValue = value->clone();
-  
+
   return *this;
 }
 
@@ -260,14 +260,14 @@ JamomaAddress::AccessMode JamomaAddress::getAccessMode() const
 Address & JamomaAddress::setAccessMode(AccessMode accessMode)
 {
   mAccessMode = accessMode;
-  
+
   if (mAccessMode == AccessMode::BI)
     mObject.set("service", kTTSym_parameter);
   else if (mAccessMode == AccessMode::SET)
     mObject.set("service", kTTSym_message);
   else if (mAccessMode == AccessMode::GET)
     mObject.set("service", kTTSym_return);
-  
+
   return *this;
 }
 
@@ -279,14 +279,14 @@ const shared_ptr<Domain> & JamomaAddress::getDomain() const
 Address & JamomaAddress::setDomain(shared_ptr<Domain> domain)
 {
   mDomain = domain;
-  
+
   TTValue range, v;
-  
+
   if (mDomain->getValues().empty())
   {
     convertValueIntoTTValue(mDomain->getMin(), v);
     range.append(v);
-    
+
     convertValueIntoTTValue(mDomain->getMax(), v);
     range.append(v);
   }
@@ -298,9 +298,9 @@ Address & JamomaAddress::setDomain(shared_ptr<Domain> domain)
       range.append(v);
     }
   }
-  
+
   mObject.set("rangeBounds", range);
-  
+
   return *this;
 }
 
@@ -312,7 +312,7 @@ JamomaAddress::BoundingMode JamomaAddress::getBoundingMode() const
 Address & JamomaAddress::setBoundingMode(BoundingMode boundingMode)
 {
   mBoundingMode = boundingMode;
-  
+
   if (mBoundingMode == BoundingMode::FREE)
     mObject.set("rangeClipmode", kTTSym_none);
   else if (mBoundingMode == BoundingMode::CLIP)
@@ -321,7 +321,7 @@ Address & JamomaAddress::setBoundingMode(BoundingMode boundingMode)
     mObject.set("rangeClipmode", kTTSym_wrap);
   else if (mBoundingMode == BoundingMode::FOLD)
     mObject.set("rangeClipmode", kTTSym_fold);
-  
+
   return *this;
 }
 
@@ -333,19 +333,19 @@ bool JamomaAddress::getRepetitionFilter() const
 Address & JamomaAddress::setRepetitionFilter(bool repetitionFilter)
 {
   mRepetitionFilter = repetitionFilter;
-  
+
   mObject.set("repetitionsFilter", repetitionFilter);
-  
+
   return *this;
 }
 
 # pragma mark -
 # pragma mark Callback
 
-void JamomaAddress::addCallback(ValueCallback* callback)
+Address::iterator JamomaAddress::addCallback(ValueCallback callback)
 {
-  callbacks().push_back(callback);
-  
+  auto it = CallbackContainer::addCallback(std::move(callback));
+
   if (callbacks().size() == 1)
   {
     //! \todo use the device protocol to start address value observation
@@ -357,12 +357,14 @@ void JamomaAddress::addCallback(ValueCallback* callback)
       TTMirrorPtr(mObject.instance())->enableListening(*valueAttribute, true);
     }
   }
+
+  return it;
 }
 
-void JamomaAddress::removeCallback(ValueCallback* callback)
+void JamomaAddress::removeCallback(Address::iterator callback)
 {
-  callbacks().erase(find(callbacks().begin(), callbacks().end(), callback));
-  
+  CallbackContainer::removeCallback(callback);
+
   if (callbacks().size() == 0)
   {
     //! \todo use the device protocol to stop address value observation
@@ -383,18 +385,18 @@ TTErr JamomaAddress::TTValueCallback(const TTValue& baton, const TTValue& value)
 {
   JamomaAddress * self = static_cast<JamomaAddress*>(TTPtr(baton[0]));
   TTObject aData = baton[1];
-  
+
   // check data object
   if (aData.instance() == self->mObject.instance())
   {
     self->setValue(self->convertTTValueIntoValue(value, self->mValueType));
-      
+
     for (auto callback : self->callbacks())
-      (*callback)(self->mValue);
-      
+      callback(self->mValue);
+
     return kTTErrNone;
   }
-  
+
   return kTTErrGeneric;
 }
 
@@ -406,31 +408,31 @@ Value * JamomaAddress::convertTTValueIntoValue(const TTValue& v, Value::Type val
     {
       return new OSSIA::Impulse();
     }
-      
+
     case Value::Type::BOOL :
     {
       if (v.size() == 1)
         return new OSSIA::Bool(v[0]);
-      
+
       return new OSSIA::Bool();
     }
-      
+
     case Value::Type::INT :
     {
       if (v.size() == 1)
         return new OSSIA::Int(v[0]);
-      
+
       return new OSSIA::Int();
     }
-      
+
     case Value::Type::FLOAT :
     {
       if (v.size() == 1)
         return new OSSIA::Float(v[0]);
-      
+
       return new OSSIA::Float();
     }
-      
+
     case Value::Type::CHAR :
     {
       if (v.size() == 1)
@@ -441,10 +443,10 @@ Value * JamomaAddress::convertTTValueIntoValue(const TTValue& v, Value::Type val
           return new OSSIA::Char(c_value[0]);
         }
       }
-      
+
       return new OSSIA::Char();
     }
-      
+
     case Value::Type::STRING :
     {
       if (v.size() == 1)
@@ -455,10 +457,10 @@ Value * JamomaAddress::convertTTValueIntoValue(const TTValue& v, Value::Type val
           return new OSSIA::String(s_value.c_str());
         }
       }
-      
+
       return new OSSIA::String();
     }
-      
+
     case Value::Type::DESTINATION :
     {
       /*
@@ -468,26 +470,26 @@ Value * JamomaAddress::convertTTValueIntoValue(const TTValue& v, Value::Type val
        {
        //! \todo retreive the Address from the symbol
        //TTAddress s_value = v[0];
-       
+
        return new OSSIA::Destination();
        }
        }
-       
+
        return new OSSIA::Destination();
        */
     }
-      
+
     case Value::Type::BEHAVIOR :
     {}
-      
+
     case Value::Type::TUPLE :
     {
       vector<const Value*> t_value;
-      
+
       for (const auto & e : v)
       {
         Value::Type type;
-        
+
         if (e.type() == kTypeBoolean)
         {
           type = Value::Type::BOOL;
@@ -511,14 +513,14 @@ Value * JamomaAddress::convertTTValueIntoValue(const TTValue& v, Value::Type val
         {
           continue;
         }
-        
+
         TTValue t(e);
         t_value.push_back(convertTTValueIntoValue(t, type));
       }
-      
+
       return new OSSIA::Tuple(t_value);
     }
-      
+
     case Value::Type::GENERIC :
     {
       return nullptr; // todo
@@ -534,68 +536,68 @@ void JamomaAddress::convertValueIntoTTValue(const Value * value, TTValue & v) co
     {
       break;
     }
-      
+
     case Value::Type::BOOL :
     {
       Bool * b = (Bool*)value;
       v = TTBoolean(b->value);
       break;
     }
-      
+
     case Value::Type::INT :
     {
       Int * i = (Int*)value;
       v = TTInt32(i->value);
       break;
     }
-      
+
     case Value::Type::FLOAT :
     {
       Float * f = (Float*)value;
       v = TTFloat64(f->value);
       break;
     }
-      
+
     case Value::Type::CHAR :
     {
       Char * c = (Char*)value;
       v = TTSymbol(c->value);
       break;
     }
-      
+
     case Value::Type::STRING :
     {
       String * s = (String*)value;
       v = TTSymbol(s->value);
       break;
     }
-      
+
     case Value::Type::DESTINATION :
     {
       Destination * d = (Destination*)value;
       v = TTAddress(buildNodePath(d->value).data());
       break;
     }
-      
+
     case Value::Type::BEHAVIOR :
     {}
-      
+
     case Value::Type::TUPLE :
     {
       Tuple * t = (Tuple*)value;
-      
+
       for (const auto & e : t->value)
       {
         TTValue n;
         convertValueIntoTTValue(e, n);
-        
+
         if (n.size())
           v.append(n[0]);
       }
-      
+
       break;
     }
-      
+
     case Value::Type::GENERIC :
     {
       //! \todo GENERIC case
@@ -609,7 +611,7 @@ string JamomaAddress::buildNodePath(shared_ptr<Node> node) const
   string path;
   string name = node->getName();
   shared_ptr<Node> parent = node->getParent();
-  
+
   if (parent != nullptr)
   {
     path += buildNodePath(parent);
@@ -622,6 +624,6 @@ string JamomaAddress::buildNodePath(shared_ptr<Node> node) const
     //! \todo use device name
     path = name;
   }
-  
+
   return path;
 }

--- a/Tests/Editor/AutomationTest.cpp
+++ b/Tests/Editor/AutomationTest.cpp
@@ -28,7 +28,7 @@ class AutomationTest : public QObject
     }
 
 private Q_SLOTS:
-    
+
     /*! test life cycle and accessors functions */
     void test_basic()
     {
@@ -51,7 +51,7 @@ private Q_SLOTS:
 
         //! \todo test clone()
     }
-    
+
     /*! test execution functions */
     //! \todo test state()
     void test_execution()
@@ -60,8 +60,7 @@ private Q_SLOTS:
         auto local_device = Device::create(local_protocol, "test");
         local_device->emplace(local_device->children().begin(), "child");
         auto address = local_device->children().front()->createAddress(Value::Type::FLOAT);
-        ValueCallback callback = std::bind(&AutomationTest::address_callback, this, _1);
-        address->addCallback(&callback);
+        address->addCallback([&] (const Value* v) { address_callback(v); });
 
         auto curve = Curve<float>::create();
         auto linearSegment = CurveSegmentLinear<float>::create(curve);

--- a/Tests/Editor/ExpressionAtomTest.cpp
+++ b/Tests/Editor/ExpressionAtomTest.cpp
@@ -19,7 +19,7 @@ class ExpressionAtomTest : public QObject
     }
 
 private Q_SLOTS:
-    
+
     /*! evaluate expressions with impulse values */
     void test_impulse()
     {
@@ -340,8 +340,8 @@ private Q_SLOTS:
                                                            ExpressionAtom::Operator::EQUAL,
                                                            new Destination(localIntNode2));
 
-        ResultCallback callback = std::bind(&ExpressionAtomTest::result_callback, this, _1);
-        testDestinationExpr->addCallback(&callback);
+        auto callback = [&] (bool b) { result_callback(b); };
+        auto callback_index = testDestinationExpr->addCallback(callback);
 
         QVERIFY(testDestinationExpr->callbacks().size() == 1);
 
@@ -361,7 +361,7 @@ private Q_SLOTS:
 
         QVERIFY(m_result_callback_called == true && m_result == true);
 
-        testDestinationExpr->removeCallback(&callback);
+        testDestinationExpr->removeCallback(callback_index);
 
         QVERIFY(testDestinationExpr->callbacks().size() == 0);
 

--- a/Tests/Editor/ExpressionCompositionTest.cpp
+++ b/Tests/Editor/ExpressionCompositionTest.cpp
@@ -19,7 +19,7 @@ class ExpressionCompositionTest : public QObject
     }
 
 private Q_SLOTS:
-    
+
     /*! test AND operator */
     void test_AND()
     {
@@ -137,7 +137,7 @@ private Q_SLOTS:
                                                                         testDestinationExprB);
 
         ResultCallback callback = std::bind(&ExpressionCompositionTest::result_callback, this, _1);
-        testDestinationComposition->addCallback(&callback);
+        auto callback_index = testDestinationComposition->addCallback(callback);
 
         QVERIFY(testDestinationComposition->callbacks().size() == 1);
 
@@ -165,7 +165,7 @@ private Q_SLOTS:
 
         QVERIFY(m_result_callback_called == true && m_result == true);
 
-        testDestinationComposition->removeCallback(&callback);
+        testDestinationComposition->removeCallback(callback_index);
 
         QVERIFY(testDestinationComposition->callbacks().size() == 0);
 

--- a/Tests/Editor/ExpressionNotTest.cpp
+++ b/Tests/Editor/ExpressionNotTest.cpp
@@ -19,7 +19,7 @@ class ExpressionNotTest : public QObject
     }
 
 private Q_SLOTS:
-    
+
     /*! test life cycle and accessors functions */
     void test_basic()
     {
@@ -51,7 +51,7 @@ private Q_SLOTS:
         auto testDestinationExprNot = ExpressionNot::create(testDestinationExpr);
 
         ResultCallback callback = std::bind(&ExpressionNotTest::result_callback, this, _1);
-        testDestinationExprNot->addCallback(&callback);
+        auto callback_index = testDestinationExprNot->addCallback(callback);
 
         QVERIFY(testDestinationExprNot->callbacks().size() == 1);
 
@@ -79,7 +79,7 @@ private Q_SLOTS:
 
         QVERIFY(m_result_callback_called == true && m_result == false);
 
-        testDestinationExprNot->removeCallback(&callback);
+        testDestinationExprNot->removeCallback(callback_index);
 
         QVERIFY(testDestinationExprNot->callbacks().size() == 0);
 


### PR DESCRIPTION
Theo,

I changed for pointers to iterators because it was not possible (easily) to do something like : 

```
    c.addCallback([] (bool b) { print(b); });
```

Besides, this may have caused subtle bugs. For example,  Documentation/Examples/Editor/state.cpp#L71 :
```
if (parameter_name == "bitdepth")
{
    cout << "/deg/bitdepth node found" << endl;

    bitdepthAddress = parameter->getAddress();
    bitdepthMessage = Message::create(bitdepthAddress, bitdepthAddress->pullValue());

    // change the value
    Int i(10);
    bitdepthAddress->pushValue(&i);
                    
    // attach to callback to display later value update
    ValueCallback callback = printValueCallback;  //// here
    bitdepthAddress->addCallback(&callback); //// we take the address
} //// <- here callback is deleted and we have the address of a deleted object in the container
... stuff happens afterwards ...
```

Now they are stored by value, which means that such problems cannot happen.

(ps: sorry, my editor removed all the empty whitespaces on the lines... to see a "uncluttered" git diff, it is possible to append `w=1` to the github url. e.g. https://github.com/OSSIA/API/compare/feature/iterator_callbacks?w=1)


Please note that I ran the test and that they seemed to be fine apart from the Scenario and TimeValue test but in both cases it seemed to be a problem due to TimeValue's infinity value.