### PR TITLE
Add callbacks for adding / removing child Node

### DIFF
--- a/Headers/Editor/Value.h
+++ b/Headers/Editor/Value.h
@@ -303,7 +303,7 @@ struct Tuple final : public Value
 
   /*! constructor for one value
    \param const value */
-  Tuple(const Value* v);
+  explicit Tuple(const Value* v);
 
   /*! constructor for any number of values
   \param const value

--- a/Headers/Network/Node.h
+++ b/Headers/Network/Node.h
@@ -39,9 +39,10 @@ enum class NodeChange
 };
   
 /*! to track any modifications done on a node or its children
- \param the node that have changed 
+ \param the node that have changed
+ \param the name of the node that have changed (when it has been renamed it is the former name)
  \param the change type */
-using NodeChangeCallback = std::function<void(const Node&, NodeChange)>;
+using NodeChangeCallback = std::function<void(const Node&, const std::string&, NodeChange)>;
 
 class Node : public CallbackContainer<NodeChangeCallback>
 {

--- a/Headers/Network/Node.h
+++ b/Headers/Network/Node.h
@@ -41,7 +41,7 @@ enum class NodeChange
 /*! to track any modifications done on a node or its children
  \param the node that have changed 
  \param the change type */
-  using NodeChangeCallback = std::function<void(std::shared_ptr<Node>, NodeChange)>;
+using NodeChangeCallback = std::function<void(const Node&, NodeChange)>;
 
 class Node : public CallbackContainer<NodeChangeCallback>
 {

--- a/Implementations/Jamoma/Includes/Network/JamomaNode.h
+++ b/Implementations/Jamoma/Includes/Network/JamomaNode.h
@@ -128,7 +128,7 @@ public:
   void buildAddress();
   
   /* get any child change back */
-  void childNodeChangeCallback(const Node&, NodeChange);
+  void childNodeChangeCallback(const Node&, const std::string&, NodeChange);
 
   /* remove all Addresses by closing the listening before deletion */
   void removeAddresses();

--- a/Implementations/Jamoma/Includes/Network/JamomaNode.h
+++ b/Implementations/Jamoma/Includes/Network/JamomaNode.h
@@ -128,7 +128,7 @@ public:
   void buildAddress();
   
   /* get any child change back */
-  void childNodeChangeCallback(shared_ptr<Node>, NodeChange);
+  void childNodeChangeCallback(const Node&, NodeChange);
 
   /* remove all Addresses by closing the listening before deletion */
   void removeAddresses();

--- a/Implementations/Jamoma/Sources/Network/Address.cpp
+++ b/Implementations/Jamoma/Sources/Network/Address.cpp
@@ -27,9 +27,6 @@ JamomaAddress::~JamomaAddress()
 {
   if(mValue)
     delete mValue;
-  
-  // use the device protocol to stop address value observation
-  mNode.lock()->getDevice()->getProtocol()->observeAddressValue(shared_from_this(), false);
 }
 
 Address::~Address()

--- a/Implementations/Jamoma/Sources/Network/Node.cpp
+++ b/Implementations/Jamoma/Sources/Network/Node.cpp
@@ -569,8 +569,9 @@ void JamomaNode::buildAddress()
 
 void JamomaNode::childNodeChangeCallback(shared_ptr<Node> child, NodeChange change)
 {
-  // notify observers
-  send(child, change);
+  // only notify tree structure changes to parent
+  if (change == NodeChange::EMPLACED || change == NodeChange::ERASED)
+    send(child, change);
 }
 
 void JamomaNode::removeAddresses()

--- a/Tests/Network/NodeTest.cpp
+++ b/Tests/Network/NodeTest.cpp
@@ -15,24 +15,24 @@ class NodeTest : public QObject
     std::string node_address_created;
     std::string node_address_removed;
 
-    void node_change_callback(const OSSIA::Node& node, OSSIA::NodeChange change)
+    void node_change_callback(const OSSIA::Node& node, const std::string& name, OSSIA::NodeChange change)
     {
         switch (change)
         {
         case NodeChange::EMPLACED:
-            node_emplaced = node.getName();
+            node_emplaced = name;
             break;
         case NodeChange::ERASED:
-            node_erased = node.getName();
+            node_erased = name;
             break;
         case NodeChange::RENAMED:
-            node_renamed = node.getName();
+            node_renamed = name;
             break;
         case NodeChange::ADDRESS_CREATED:
-            node_address_created = node.getName();
+            node_address_created = name;
             break;
         case NodeChange::ADDRESS_REMOVED:
-            node_address_removed = node.getName();
+            node_address_removed = name;
             break;
         }
     }
@@ -116,7 +116,7 @@ private Q_SLOTS:
     {
         auto local_protocol = Local::create();
         auto local_device = Device::create(local_protocol, "test");
-        auto callback = std::bind(&NodeTest::node_change_callback, this, _1, _2);
+        auto callback = std::bind(&NodeTest::node_change_callback, this, _1, _2, _3);
 
         CallbackContainer<NodeChangeCallback>::iterator local_device_callback_it = local_device->addCallback(callback);
         QVERIFY(local_device->callbacks().size() == 1);
@@ -142,7 +142,7 @@ private Q_SLOTS:
             QVERIFY(node_address_removed == "child");
 
             node->setName("foo");
-            QVERIFY(node_renamed == "foo");
+            QVERIFY(node_renamed == "child");
 
             // don't need to observe the node itself anymore
             node->removeCallback(node_callback_it);

--- a/Tests/Network/NodeTest.cpp
+++ b/Tests/Network/NodeTest.cpp
@@ -3,10 +3,39 @@
 #include <iostream>
 
 using namespace OSSIA;
+using namespace std::placeholders;
 
 class NodeTest : public QObject
 {
     Q_OBJECT
+
+    std::string node_emplaced;
+    std::string node_erased;
+    std::string node_renamed;
+    std::string node_address_created;
+    std::string node_address_removed;
+
+    void node_change_callback(const OSSIA::Node& node, OSSIA::NodeChange change)
+    {
+        switch (change)
+        {
+        case NodeChange::EMPLACED:
+            node_emplaced = node.getName();
+            break;
+        case NodeChange::ERASED:
+            node_erased = node.getName();
+            break;
+        case NodeChange::RENAMED:
+            node_renamed = node.getName();
+            break;
+        case NodeChange::ADDRESS_CREATED:
+            node_address_created = node.getName();
+            break;
+        case NodeChange::ADDRESS_REMOVED:
+            node_address_removed = node.getName();
+            break;
+        }
+    }
 
 private Q_SLOTS:
 
@@ -65,7 +94,7 @@ private Q_SLOTS:
                                    [&] (const std::shared_ptr<OSSIA::Node>& elt) { return elt->getName() == "child"; });
             if(it != children.end())
             {
-               node->erase(it);
+               local_device->erase(it);
                removed = true;
             }
 
@@ -80,6 +109,51 @@ private Q_SLOTS:
 
             QVERIFY(node->getName() == "child");
         }
+    }
+
+    /*! test callback notifications */
+    void test_callback()
+    {
+        auto local_protocol = Local::create();
+        auto local_device = Device::create(local_protocol, "test");
+        auto callback = std::bind(&NodeTest::node_change_callback, this, _1, _2);
+
+        CallbackContainer<NodeChangeCallback>::iterator local_device_callback_it = local_device->addCallback(callback);
+        QVERIFY(local_device->callbacks().size() == 1);
+
+        // edit a node and its address, rename it and then remove it
+        {
+            Container<OSSIA::Node>::iterator it = local_device->emplace(local_device->children().begin(), "child");
+            std::shared_ptr<OSSIA::Node> node = *it;
+
+            QVERIFY(node_emplaced == "child");
+
+            // the node should be observed by the local device
+            QVERIFY(node->callbacks().size() == 1);
+
+            // add a callback on the node itself to get any changes on it
+            CallbackContainer<NodeChangeCallback>::iterator node_callback_it = node->addCallback(callback);
+            QVERIFY(node->callbacks().size() == 2);
+
+            node->createAddress();
+            QVERIFY(node_address_created == "child");
+
+            node->removeAddress();
+            QVERIFY(node_address_removed == "child");
+
+            node->setName("foo");
+            QVERIFY(node_renamed == "foo");
+
+            // don't need to observe the node itself anymore
+            node->removeCallback(node_callback_it);
+            QVERIFY(node->callbacks().size() == 1);
+
+            local_device->erase(it);
+            QVERIFY(node_erased == "foo");
+        }
+
+        local_device->removeCallback(local_device_callback_it);
+        QVERIFY(local_device->callbacks().size() == 0);
     }
 };
 


### PR DESCRIPTION
This commits adds a callback mechanism when a Node's
child gets added / removed.

Because it would IMHO be costly to have callbacks registered for each Node,
I choose to put the callbacks list in the Device.

If a node is inside the hierarchy of a device (i.e. the important case)
calling emplaceAndNotify / eraseAndNotify will then run the callbacks
registered in the device.

This way a single function has to be registered.

This is used in i-score for the Local device (see recent commits).
This allows to automatically update the Device explorer when for instant
a Constraint is added (instead of having to do Refresh namespace each time).

I kept separate emplace / emplaceAndNotify because if a Node is added
by hand from i-score, we do not want (I think) to get notified of the
node that was just added.